### PR TITLE
Removed abspath call

### DIFF
--- a/src/llscheck.lua
+++ b/src/llscheck.lua
@@ -213,7 +213,6 @@ end
 ---@return string? filepath Validated filepath
 ---@return string? error Error message
 local function validate_file(filepath)
-   filepath = path.abspath(filepath)
    if not path.exists(filepath) then
       return nil, string.format("'%s': No such file or directory", filepath)
    end


### PR DESCRIPTION
Fixes: https://github.com/jeffzi/llscheck/issues/7

Retaining the relative workspace path makes sure that lua-language-server does not treat absolute library paths as part of the project's diagnostics.